### PR TITLE
Month support

### DIFF
--- a/lib/cart/rules/bulk_discount.rb
+++ b/lib/cart/rules/bulk_discount.rb
@@ -4,14 +4,16 @@ module Cart
     # Rule: get a lower price for volume.
     class BulkDiscount
 
-      def initialize(code, bonus_qty, discount_rate)
+      def initialize(code, bonus_qty, discount_rate, month_limit=nil)
         @code = code
         @bonus_qty = bonus_qty
         @discount_rate = discount_rate
+        @month_limit = month_limit
       end
 
       def does_apply?(cart_item, month=nil)
-        @code.eql?(cart_item.product) && @bonus_qty <= cart_item.quantity
+        @code.eql?(cart_item.product) && @bonus_qty <= cart_item.quantity &&
+          (@month_limit == nil || (month && month < @month_limit))
       end
 
       def bill_items(cart_item)

--- a/lib/cart/rules/buy_some_get_some_free.rb
+++ b/lib/cart/rules/buy_some_get_some_free.rb
@@ -8,15 +8,17 @@ module Cart
     # (e.g. 3 for 2).
     class BuySomeGetSomeFree
 
-      def initialize(products, code, bonus_qty, discount_qty)
+      def initialize(products, code, bonus_qty, discount_qty, month_limit=nil)
         @products = products
         @code = code
         @bonus_qty = bonus_qty
         @discount_qty = discount_qty
+        @month_limit = month_limit
       end
 
       def does_apply?(cart_item, month=nil)
-        @code.eql?(cart_item.product) && cart_item.quantity >= @bonus_qty
+        @code.eql?(cart_item.product) && cart_item.quantity >= @bonus_qty &&
+          (@month_limit == nil || (month && month < @month_limit))
       end
 
       def bill_items(cart_item)

--- a/spec/cart/rules/bulk_discount_spec.rb
+++ b/spec/cart/rules/bulk_discount_spec.rb
@@ -2,12 +2,9 @@ require_relative '../../spec_helper'
 
 describe Cart::Rules::BulkDiscount do
 
-  before :context do
-    @rule = Cart::Rules::BulkDiscount.new('ult_large', 3, 39.9)
-  end
-
-  context 'Bulk discount rule' do
+  context 'Bulk discount rule (no month)' do
     before :example do
+      @rule = Cart::Rules::BulkDiscount.new('ult_large', 3, 39.9)
       @item = Cart::Item.new('ult_large', 3)
     end
 
@@ -25,6 +22,27 @@ describe Cart::Rules::BulkDiscount do
     describe '#bill_items' do
       it 'Applies the discounted price' do
         expect(@rule.bill_items(@item).first.price).to eq(39.9 * 3)
+      end
+    end
+  end
+
+  context 'Bulk discount rule (first month only)' do
+    before :example do
+      @rule = Cart::Rules::BulkDiscount.new('ult_large', 3, 39.9, 1)
+      @item = Cart::Item.new('ult_large', 3)
+    end
+
+    describe '#does_apply?' do
+      it 'doesn''t apply if no month is specified' do
+        expect(@rule.does_apply?(@item)).to be_falsey
+      end
+
+      it 'doesn''t apply if the month is later than the limit' do
+        expect(@rule.does_apply?(@item, 1)).to be_falsey
+      end
+
+      it 'applies if the month is earlier than the limit' do
+        expect(@rule.does_apply?(@item, 0)).to be_truthy
       end
     end
   end

--- a/spec/cart/rules/buy_some_get_some_free_spec.rb
+++ b/spec/cart/rules/buy_some_get_some_free_spec.rb
@@ -1,14 +1,11 @@
 require_relative '../../spec_helper'
 
 describe Cart::Rules::BuySomeGetSomeFree do
-  
-  before :context do
-    @rule = Cart::Rules::BuySomeGetSomeFree.new(Cart::Config::Products.new,
-                                                'ult_large', 3, 2)
-  end
 
-  context 'Buy some get some free rule' do
+  context 'Buy some get some free rule (no month)' do
     before :example do
+      @rule = Cart::Rules::BuySomeGetSomeFree.new(Cart::Config::Products.new,
+                                                  'ult_large', 3, 2)
       @item = Cart::Item.new('ult_large', 3)
     end
 
@@ -35,6 +32,28 @@ describe Cart::Rules::BuySomeGetSomeFree do
 
       it 'Bills at the discounted quantity' do
         expect(@rule.bill_items(@item).first.price).to eq(44.90 * 2)
+      end
+    end
+  end
+  
+  context 'Buy some get some free rule (first month only)' do
+    before :example do
+      @rule = Cart::Rules::BuySomeGetSomeFree.new(Cart::Config::Products.new,
+                                                  'ult_large', 3, 2, 1)
+      @item = Cart::Item.new('ult_large', 3)
+    end
+
+    describe '#does_apply?' do
+      it 'doesn''t apply if no month is specified' do
+        expect(@rule.does_apply?(@item)).to be_falsey
+      end
+
+      it 'doesn''t apply if the month is later than the limit' do
+        expect(@rule.does_apply?(@item, 1)).to be_falsey
+      end
+
+      it 'applies if the month is earlier than the limit' do
+        expect(@rule.does_apply?(@item, 0)).to be_truthy
       end
     end
   end


### PR DESCRIPTION
The 3 for 2 deals and bulk discounts need to have support for a month cutoff (i.e. first month only).
